### PR TITLE
media on members and projects

### DIFF
--- a/_data/media.yml
+++ b/_data/media.yml
@@ -1,0 +1,10 @@
+-
+  title: 'Video Tip of the Week: UpSet about genomics Venn Diagrams?'
+  outlet: 'The OpenHelix Blog'
+  date: '2014'
+  url: 'http://blog.openhelix.eu/?p=20201'
+  members:
+    - nils-gehlenborg
+  projects:
+    - upsetr
+

--- a/_data/media.yml
+++ b/_data/media.yml
@@ -3,6 +3,7 @@
   outlet: 'The OpenHelix Blog'
   date: '2014'
   url: 'http://blog.openhelix.eu/?p=20201'
+  blurb: '"Looking for both effective and efficient representation of the types of data genomics researchers need, this interactive tool is a really nice way to explore which items belong in which subset. And, of course, which ones don’t.  But that’s just the beginning."'
   members:
     - nils-gehlenborg
   projects:

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -27,6 +27,26 @@ layout: docs
       </ul>
     {% endif %}
 
+    {% capture media_list %}
+      {% for media in site.data.media %}
+        {% for member in media.members %}
+          {% if member == id %}
+            <li>
+              {{ media.outlet }} ({{ media.date }}):
+              <a href="{{ media.url }}">{{ media.title }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% endcapture %}
+    {% assign media_list = media_list | strip %}
+    {% if media_list != '' %}
+      <h3 id="media">Media</h3>
+      <ul>
+        {{ media_list }}
+      </ul>
+    {% endif %}
+
     {% capture publications_list %}
       {% for publication in site.publications %}
         {% for member in publication.members %}
@@ -62,24 +82,5 @@ layout: docs
     {% endfor %}
     </ul>
 
-    {% capture media_list %}
-      {% for media in site.data.media %}
-        {% for member in media.members %}
-          {% if member == id %}
-            <li>
-              {{ media.outlet }} ({{ media.date }}):
-              <a href="{{ media.url }}">{{ media.title }}</a>
-            </li>
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
-    {% endcapture %}
-    {% assign media_list = media_list | strip %}
-    {% if media_list != '' %}
-      <h3 id="media">Media</h3>
-      <ul>
-        {{ media_list }}
-      </ul>
-    {% endif %}
   </aside>
 </div>

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -52,14 +52,34 @@ layout: docs
     </div>
 
     <h3 id="projects">Projects</h3>
-      <ul>
-      {% for project in site.projects %}
-        {% for member in project.members %}
+    <ul>
+    {% for project in site.projects %}
+      {% for member in project.members %}
+        {% if member == id %}
+          <li><a href="{{ project.url }}">{{ project.name }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+    </ul>
+
+    {% capture media_list %}
+      {% for media in site.data.media %}
+        {% for member in media.members %}
           {% if member == id %}
-            <li><a href="{{ project.url }}">{{ project.name }}</a></li>  
+            <li>
+              {{ media.outlet }} ({{ media.date }}):
+              <a href="{{ media.url }}">{{ media.title }}</a>
+            </li>
           {% endif %}
         {% endfor %}
       {% endfor %}
+    {% endcapture %}
+    {% assign media_list = media_list | strip %}
+    {% if media_list != '' %}
+      <h3 id="media">Media</h3>
+      <ul>
+        {{ media_list }}
       </ul>
+    {% endif %}
   </aside>
 </div>

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -31,10 +31,13 @@ layout: docs
       {% for media in site.data.media %}
         {% for member in media.members %}
           {% if member == id %}
-            <li>
+            <dt>
               {{ media.outlet }} ({{ media.date }}):
               <a href="{{ media.url }}">{{ media.title }}</a>
-            </li>
+            </dt>
+            <dd>
+              {{ media.blurb }}
+            </dd>
           {% endif %}
         {% endfor %}
       {% endfor %}
@@ -42,9 +45,9 @@ layout: docs
     {% assign media_list = media_list | strip %}
     {% if media_list != '' %}
       <h3 id="media">Media</h3>
-      <ul>
+      <dl>
         {{ media_list }}
-      </ul>
+      </dl>
     {% endif %}
 
     {% capture publications_list %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -30,6 +30,26 @@ layout: docs
     </ul>
     {% endif %}
 
+    {% capture media_list %}
+      {% for media in site.data.media %}
+        {% for project in media.projects %}
+          {% if project == id %}
+            <li>
+              {{ media.outlet }} ({{ media.date }}):
+              <a href="{{ media.url }}">{{ media.title }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% endcapture %}
+    {% assign media_list = media_list | strip %}
+    {% if media_list != '' %}
+      <h3 id="media">Media</h3>
+      <ul>
+        {{ media_list }}
+      </ul>
+    {% endif %}
+
     {% if page.github_repositories.size > 0 or page.docker_repositories.size > 0 %}
     <h3>Software</h3>
 

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -34,10 +34,13 @@ layout: docs
       {% for media in site.data.media %}
         {% for project in media.projects %}
           {% if project == id %}
-            <li>
+            <dt>
               {{ media.outlet }} ({{ media.date }}):
               <a href="{{ media.url }}">{{ media.title }}</a>
-            </li>
+            </dt>
+            <dd>
+              {{ media.blurb }}
+            </dd>
           {% endif %}
         {% endfor %}
       {% endfor %}
@@ -45,9 +48,9 @@ layout: docs
     {% assign media_list = media_list | strip %}
     {% if media_list != '' %}
       <h3 id="media">Media</h3>
-      <ul>
+      <dl>
         {{ media_list }}
-      </ul>
+      </dl>
     {% endif %}
 
     {% if page.github_repositories.size > 0 or page.docker_repositories.size > 0 %}


### PR DESCRIPTION
@ngehlenborg ? Towards #79 

Here's what it looks like on the member page and the project page:

<img width="802" alt="screen shot 2017-05-04 at 10 18 56 am" src="https://cloud.githubusercontent.com/assets/730388/25708093/799296d6-30b3-11e7-9b83-dd1da7f51aad.png">

(This is actually just jekyll data, rather than a "collection", since we do not want any stand-alone pages for these.)

Even assuming it looks ok, should probably get more items in there before releasing:
- Probably do not actually want to list UpSet press for UpSetR?
- Do we only want to list media relating to projects, or are we interested in other citations (https://www.google.com/search?q=nils+gehlenborg&tbm=nws) that present you or other lab members as knowledgeable people?