### PR TITLE
This works if we have every PDF

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -28,10 +28,9 @@ layout: docs
       <a href="{{ page.publisher }}">{{ page.publisher }}</a>
     {% endif %}
 
-    {% if page.pdf %}
-      <h3>PDF</h3>
-      <a href="{{ page.pdf }}">{{ page.pdf }}</a>
-    {% endif %}
+    <h3>PDF</h3>
+    {% assign basename = page.id | split: '/' | last %}
+    <a href="http://pdfs.gehlenborglab.org/{{ basename }}.pdf">http://pdfs.gehlenborglab.org/{{ basename }}.pdf</a>
   </div>
 
   <aside class="usa-width-one-third">

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -29,8 +29,7 @@ layout: docs
     {% endif %}
 
     <h3>PDF</h3>
-    {% assign basename = page.id | split: '/' | last %}
-    <a href="http://pdfs.gehlenborglab.org/{{ basename }}.pdf">http://pdfs.gehlenborglab.org/{{ basename }}.pdf</a>
+    <a href="http://pdfs.gehlenborglab.org/{{ id }}.pdf">http://pdfs.gehlenborglab.org/{{ id }}.pdf</a>
   </div>
 
   <aside class="usa-width-one-third">


### PR DESCRIPTION
If publication pages and PDFs will be one-to-one, we do not need to record that independently. If there is a mismatch, it breaks, but then it would break if you had a mismatch between the two if you specified it explicitly.

**If this looks good, still should not be merged until every pdf is on S3.**

Having an automated check would be nice, HEAD doesn't work on S3, and downloading every one is unreasonable. Maybe use an API to get a directory list from s3, and compare to publications, if it's worth worrying about?