### PR TITLE
Fix #90: Process markdown in citation on publication page.

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -18,10 +18,9 @@ layout: docs
     {% endif %}
 
     <h3>Citation</h3>
-    {{ page.cite.authors }}.
-    “{{ page.title }}”
-    {{ page.cite.published }}
-    ({{ page.year }})    
+    {% capture citation %}{{ page.cite.authors }}. “{{ page.title }}” {{ page.cite.published }} ({{ page.year }}).{% endcapture %}
+    {{ citation | markdownify }}
+    <!-- If we markdownify just one field, it is wrapped by <p> -->
     
     {% if page.publisher %}
       <h3>Publisher URL</h3>


### PR DESCRIPTION
Notice the italics and bold in the citation:

<img width="302" alt="screen shot 2017-05-18 at 6 54 35 pm" src="https://cloud.githubusercontent.com/assets/730388/26226680/7e67eaaa-3bfb-11e7-8e7a-a36479161999.png">
