### PR TITLE
Thumbnails on projects page

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -40,10 +40,13 @@ img.thumb {
   padding: 0.2em
 }
 
-table.publications td {
+table.publications td, table.projects td {
   border: none;
   padding-right: 0.2em;
   vertical-align:top;
+  h4 {
+    margin-top: 0; // So top of title matches top of image.
+  }
   img {
     width: 120px; // Match image file width
   }

--- a/projects.md
+++ b/projects.md
@@ -7,11 +7,26 @@ permalink: /research/projects/
 
 <p class="usa-font-lead">The following list is a sample of research projects that the lab is involved in.</p>
 
+<table class="projects">
+
 {% for project in site.projects %}
+<tr>
+<td>
+{% if project.gallery.size > 0 %}
+<a href="{{project.url}}"><img class="thumb"
+            src="/assets/img/publications/thumbnail/{{ project.gallery.first[0] }}"
+            alt="{{ project.gallery.first[1] }}"></a>
+{% endif %}
+</td>
+<td markdown="1">
 #### [{{ project.name }}]({{ project.url }})
 {% if project.blurb %}
   {{ project.blurb }}
 {% else %}
   {{ project.content }}
 {% endif %}
+</td>
+</tr>
 {% endfor %}
+
+</table>


### PR DESCRIPTION
@ngehlenborg : It looks like this right now... It could be merged, or you can wait till more projects have images. Fix #146.

<img width="258" alt="screen shot 2018-09-26 at 7 27 44 pm" src="https://user-images.githubusercontent.com/730388/46114858-855bc400-c1c2-11e8-848b-5852ed3e4492.png">
