### PR TITLE
add letters of recommendation

### DIFF
--- a/letters-of-recommendation.md
+++ b/letters-of-recommendation.md
@@ -1,0 +1,31 @@
+---
+layout: home
+
+title: Letters of Recommendation
+
+permalink: /education/letters-of-recommendation/
+---
+## Letters of Recommendation
+
+Nils writes letters of recommendation for many trainees every year. To streamline the process and to avoid delayed submission of your letters, please follow the instructions below.
+
+1. At least **one month** before the deadline for the first letter, contact Nils by email (nils@hms.harvard.edu) and get confirmation that he will be able to write a letter for you. 
+1. At least **two weeks** before the first letter is due, share a Google Drive folder with Nils (nils@hms.harvard.edu) and Nichole Parker (nichole_parker@hms.harvard.edu) that contains the documents listed below. Send an email to Nichole Parker and Nils with a link to a folder and the (first) letter's due date.
+    1. PDF of your current CV
+    1. PDF of a final or close to final draft of your statement of purpose, research proposal, or research statement
+    1. Google Sheet containing the following columns (you can update this but always send an email if you do so):
+        1. due date of each letter,
+        1. name of institution you’re applying to
+        1. name of program you’re applying to
+        1. additional information
+    1. Optional: Google Doc with key talking points and names of other letter writers
+1. Around **three days** before the (first) deadline, send Nils a reminder if you haven’t received confirmation from the submission system that your letter has been submitted.
+1. **On the day** the letter is due, send Nils and Nichole a reminder if you haven’t received confirmation from the submission system that your letter has been submitted.
+1. When entering my information into application forms, please provide the following: 
+    1. Name: _Nils Gehlenborg_
+    1. Degree: _PhD_
+    1. Title: _Assistant Professor of Biomedical Informatics_
+    1. Institution: _Harvard Medical School_
+    1. Department: _Biomedical Informatics_
+    1. Email: _nils@hms.harvard.edu_
+    1. Phone: _617-432-1535_

--- a/letters-of-recommendation.md
+++ b/letters-of-recommendation.md
@@ -9,8 +9,8 @@ permalink: /education/letters-of-recommendation/
 
 Nils writes letters of recommendation for many trainees every year. To streamline the process and to avoid delayed submission of your letters, please follow the instructions below.
 
-1. At least **one month** before the deadline for the first letter, contact Nils by email (nils@hms.harvard.edu) and get confirmation that he will be able to write a letter for you. 
-1. At least **two weeks** before the first letter is due, share a Google Drive folder with Nils (nils@hms.harvard.edu) and Nichole Parker (nichole_parker@hms.harvard.edu) that contains the documents listed below. Send an email to Nichole Parker and Nils with a link to a folder and the (first) letter's due date.
+1. At least **one month** before the deadline for the first letter, contact Nils by email ([nils@hms.harvard.edu](mailto:nils@hms.harvard.edu)) and get confirmation that he will be able to write a letter for you. 
+1. At least **two weeks** before the first letter is due, share a Google Drive folder with Nils ([nils@hms.harvard.edu](mailto:nils@hms.harvard.edu)) and Nichole Parker ([nichole_parker@hms.harvard.edu](mailto:nichole_parker@hms.harvard.edu)) that contains the documents listed below. Send an email to Nichole Parker and Nils with a link to a folder and the (first) letter's due date.
     1. PDF of your current CV
     1. PDF of a final or close to final draft of your statement of purpose, research proposal, or research statement
     1. Google Sheet containing the following columns (you can update this but always send an email if you do so):


### PR DESCRIPTION
The `1.` is translated to `<li>` in a `<ol>`. If you strongly prefer that the sublists be a. / b. / c. that's a CSS change... which isn't impossible, but I think lots of other things are more important right now.
<img width="386" alt="Screen Shot 2020-11-06 at 3 54 43 PM" src="https://user-images.githubusercontent.com/730388/98413878-6938db00-2048-11eb-98e7-94d35b247a4d.png">
