### PR TITLE
chore: add Viv publication in Nature Methods

### DIFF
--- a/_news/2020-08-13-viv-preprint.md
+++ b/_news/2020-08-13-viv-preprint.md
@@ -9,13 +9,17 @@ members:
   - trevor-manz
  
 publications:
-  - manz-2020-osfpreprint
+  - manz-2022-viv-nature-methods
 
 
 blurb: We created a novel solution to directly visualize OME-TIFF files and Bio-Formats-compatible Zarr stores containing highly multiplexed, high-bit depth, and high-resolution image data in the browser.
 ---
+
+**Update**: Viv is now published in Nature Methods!
+
 Recent advances in highly multiplexed imaging have enabled the comprehensive profiling of complex tissues in healthy and diseased states, facilitating the study of fundamental biology and human disease in spatially-resolved contexts at subcellular resolution. However, current computational infrastructure to distribute and visualize these data on the web remains complex to set up and maintain. 
 
 To address these limitations, we have developed [Viv](https://github.com/hms-dbmi/viv)—an open-source image visualization library for high-resolution multiplexed image data that is implemented in JavaScript and builds on modern web technologies. Viv directly renders Bio-Formats-compatible Zarr and OME-TIFF data formats. 
 
 Three use cases, including integration into Jupyter Notebooks ([https://github.com/hms-dbmi/vizarr](https://github.com/hms-dbmi/vizarr)) and a data portal, as well as an image viewer ([http://avivator.gehlenborglab.org](http://avivator.gehlenborglab.org)) demonstrate the capabilities of our proposed approach.
+

--- a/_news/2022-05-11-viv-paper-nature-methods.md
+++ b/_news/2022-05-11-viv-paper-nature-methods.md
@@ -1,0 +1,14 @@
+---
+title: Viv Paper Published in Nature Methods
+members:
+  - trevor-manz
+  - ilan-gold
+  - chuck-mccallum
+  - mark-keller
+  - nils-gehlenborg
+publications: manz-2022-viv-nature-methods
+blurb: Our paper about Viv was published in Nature Methods.
+---
+Our paper about Viv, a JavaScript library for multiscale visualization of high-resolution multiplexed bioimaging data, was published in Nature Methods.
+
+This effort was the result of a great collaboration with several partners in the NIH HuBMAP Consortium and the Open Microscopy Environment.

--- a/_projects/hubmap.md
+++ b/_projects/hubmap.md
@@ -20,7 +20,7 @@ collaborators:
   - katy-borner
 
 publications:
-  - manz-2020-osfpreprint
+  - manz-2022-viv-nature-methods
   - keller-2021-vitessce-osf
   - hubmap-2019-nature
 

--- a/_projects/viv.md
+++ b/_projects/viv.md
@@ -25,7 +25,7 @@ github_repositories:
     primary: true
 
 publications:
-  - manz-2020-osfpreprint
+  - manz-2022-viv-nature-methods
 
 grants:
   - nih_1Ot2Od026677

--- a/_publications/manz-2022-viv-nature-methods.md
+++ b/_publications/manz-2022-viv-nature-methods.md
@@ -9,13 +9,14 @@ members:
   - mark-keller
   - nils-gehlenborg
 
-year: 2020
-type: preprint
+year: 2022
+type: article
 
-publisher: "https://doi.org/10.31219/osf.io/wd2gu"
+publisher: "https://rdcu.be/cNlvp"
 cite:
   authors: "T Manz, I Gold, NH Patterson, C McCallum, MS Keller, BW Herr II, K Börner, J Spraggins, N Gehlenborg"
-  published: "*OSF Preprints* doi:10.31219/osf.io/wd2gu"
+  published: "*Nature Methods* **19** 515–516"
+
 ---
 Advances in highly multiplexed imaging have enabled the comprehensive profiling
 of complex tissues in healthy and diseased states, facilitating the study of


### PR DESCRIPTION
- replaces `_publications/2020-manz-osfpreprint.md` with `_publications/2022-manz-viv-nature-methods.md`
- updates old references to preprint with publication
- adds `_news/` entry announcing Viv's Nature Methods publication
