### PR TITLE
Reinstate cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,9 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-20.04
     env:
-      BUNDLE_BUILD__SASSC: "--disable-march-tune-native"
+      #sassc 2.2.1 which is a dependency of uswds-jekyll has issues with Ubuntu.
+      #see https://github.com/sass/sassc-ruby/issues/146#issuecomment-542288556.
+      BUNDLE_BUILD__SASSC: "--disable-march-tune-native" 
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ jobs:
     # Available versions:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-20.04
+    env:
+      BUNDLE_BUILD__SASSC: --disable-march-tune-native
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-20.04
     env:
-      BUNDLE_BUILD__SASSC: --disable-march-tune-native
+      BUNDLE_BUILD__SASSC: "--disable-march-tune-native"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         ruby-version: '2.7.3'
         bundler-cache: true
-        cache-version: 1
 
     - name: Build Jekyll
       run: |


### PR DESCRIPTION
Reinstating cache after successful workflows. Upon further investigation, the `sassc` installation needed to be configured to work with Github Actions reliably.