### PR TITLE
hidivelab.org website setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ jobs:
       #sassc 2.2.1 which is a dependency of uswds-jekyll has issues with Ubuntu.
       #see https://github.com/sass/sassc-ruby/issues/146#issuecomment-542288556.
       BUNDLE_BUILD__SASSC: "--disable-march-tune-native" 
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+        id-token: write
+        contents: read
 
     steps:
     - uses: actions/checkout@v2
@@ -40,13 +44,17 @@ jobs:
 
     - name: Configure AWS Credentials
       if: ${{ github.event_name == 'push' && github.ref  == 'refs/heads/main' }}
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+        aws-region: us-east-1
 
     - name: Upload to S3
       if: ${{ github.event_name == 'push' && github.ref  == 'refs/heads/main' }}
       run: |
-        aws s3 sync _site/ s3://${{ secrets.AWS_S3_BUCKET }} --acl public-read
+        aws s3 sync _site/ s3://hidivelab.org
+    
+    - name: Invalidate Cache
+      if: ${{ github.event_name == 'push' && github.ref  == 'refs/heads/main' }}
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{secrets.CF_DISTRIBUTION_ID}} --paths "/*"

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,0 +1,16 @@
+# Cloudformation templates 
+
+
+## Static-site.yaml
+Template to create a SSL certificate, S3 buckets, and Cloudfront distribution.
+Prerequisite: You must create a Route53 hosted zone prior to running this template.
+
+```
+% aws cloudformation create-stack \
+--stack-name lab-website \
+--template-body file://static-site.yaml \
+--profile hdv-admin \
+--region us-east-1 \
+--parameters ParameterKey=RootDomainName,ParameterValue=hidivelab.org  ParameterKey=HostedZoneId,ParameterValue="<HOSTED_ZONE_ID>"
+```
+

--- a/cloudformation/static-site.yaml
+++ b/cloudformation/static-site.yaml
@@ -1,0 +1,254 @@
+Description: Deploy a static website
+
+Parameters:
+    RootDomainName:
+        Description: Domain name for the website (hidivelab.org)
+        Type: String
+    HostedZoneId:
+        Description: Hosted Zone ID
+        Type: String
+    
+  
+
+Resources:
+    # Two buckets are created for website hosting - the RootBucket hosts the content,
+    # The Logging bucket hosts the access logs.
+    RootBucket:
+        Type: AWS::S3::Bucket
+        DeletionPolicy: Retain
+        Properties:
+            BucketName: !Ref RootDomainName
+            BucketEncryption:
+                ServerSideEncryptionConfiguration:
+                - ServerSideEncryptionByDefault:
+                    SSEAlgorithm: AES256
+            LoggingConfiguration:
+                DestinationBucketName: !Ref LoggingBucket
+                LogFilePrefix: !Sub
+                    - ${Domain}-logs
+                    - Domain: !Ref RootDomainName
+            Tags:
+                - Key: Environment
+                  Value: Production
+                - Key: Owner
+                  Value: hidive@hms.harvard.edu
+                - Key: Name
+                  Value: !Ref RootDomainName
+
+    LoggingBucket:
+        Type: AWS::S3::Bucket
+        Properties:
+            AccessControl: Private
+            BucketEncryption:
+                ServerSideEncryptionConfiguration:
+                - ServerSideEncryptionByDefault:
+                    SSEAlgorithm: AES256
+            BucketName: !Sub
+                - logs.${Domain}
+                - Domain: !Ref RootDomainName
+            LifecycleConfiguration:
+                Rules:
+                    - ExpirationInDays: 90
+                      Status: Enabled
+            OwnershipControls:
+                Rules:
+                - ObjectOwnership: BucketOwnerPreferred
+            PublicAccessBlockConfiguration:
+                BlockPublicAcls: true
+                BlockPublicPolicy: true
+                IgnorePublicAcls: true
+                RestrictPublicBuckets: true           
+
+    RootBucketPolicy:
+        Type: AWS::S3::BucketPolicy
+        Properties:
+            Bucket: !Ref RootBucket
+            PolicyDocument:
+                Id: CFOAIForGetBucketObjects
+                Version: 2012-10-17
+                Statement:
+                - Action: 's3:GetObject'
+                  Effect: Allow
+                  Principal: 
+                    CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+                  Resource: !Join 
+                        - ''
+                        - - 'arn:aws:s3:::'
+                          - !Ref RootBucket
+                          - /*
+
+    LogBucketPolicy:
+        Type: 'AWS::S3::BucketPolicy'
+        Properties:
+            Bucket: !Ref LoggingBucket
+            PolicyDocument:
+                Version: 2012-10-17
+                Statement:
+                    -   Action: 's3:PutObject'
+                        Effect: Allow
+                        Principal:
+                            Service: logging.s3.amazonaws.com
+                        Resource: !Join 
+                            - ''
+                            - - 'arn:aws:s3:::'
+                              - !Ref LoggingBucket
+                              - /s3/*
+                        Condition:
+                            ArnLike:
+                                'aws:SourceArn': !GetAtt 
+                                - RootBucket
+                                - Arn
+                            StringEquals:
+                                'aws:SourceAccount': !Sub '${AWS::AccountId}'
+
+    #
+    CertificateManagerCertificate:
+        Type: AWS::CertificateManager::Certificate
+        Properties:
+            # naked domain
+            DomainName: !Ref RootDomainName
+            # add www to certificate
+            SubjectAlternativeNames:
+                - !Sub 'www.${RootDomainName}'
+            ValidationMethod: DNS
+            DomainValidationOptions:
+                # DNS record for the naked domain
+                - DomainName: !Ref RootDomainName
+                  HostedZoneId: !Ref HostedZoneId
+                # DNS record for the www domain
+                - DomainName: !Sub 'www.${RootDomainName}'
+                  HostedZoneId: !Ref HostedZoneId
+    #
+    CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+            DistributionConfig:
+                Aliases:
+                    - !Ref RootDomainName
+                    - !Sub 'www.${RootDomainName}'
+                CustomErrorResponses:
+                    - ErrorCachingMinTTL: 60
+                      ErrorCode: 404
+                      ResponseCode: 404
+                      ResponsePagePath: '/404.html'
+                DefaultCacheBehavior:
+                    AllowedMethods:
+                        - GET
+                        - HEAD
+                    CachedMethods:
+                        - GET
+                        - HEAD
+                    Compress: true
+                    DefaultTTL: 86400
+                    ForwardedValues:
+                        Cookies:
+                            Forward: none
+                        QueryString: true
+                    SmoothStreaming: false
+                    TargetOriginId: !Ref RootBucket
+                    ViewerProtocolPolicy: 'allow-all'
+                    ResponseHeadersPolicyId: e61eb60c-9c35-4d20-a928-2b84e02af89c 
+                    CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized managed policy
+                    FunctionAssociations:
+                    - EventType: viewer-request
+                      FunctionARN: !GetAtt CloudFrontFunction.FunctionMetadata.FunctionARN
+                DefaultRootObject: 'index.html'
+                Enabled: true
+                HttpVersion: http2
+                IPV6Enabled: true
+                Logging:
+                    Bucket: !GetAtt LoggingBucket.DomainName
+                    IncludeCookies: false
+                    Prefix: cdn/
+                Origins:
+                    - DomainName: !Join ['', [!Ref RootBucket, '.s3.amazonaws.com']]
+                      Id: !Ref RootBucket
+                      S3OriginConfig:
+                        OriginAccessIdentity:
+                            !Join ['', ['origin-access-identity/cloudfront/', !Ref CloudFrontOriginAccessIdentity]]
+                PriceClass: PriceClass_100
+                ViewerCertificate:
+                    AcmCertificateArn: !Ref CertificateManagerCertificate
+                    MinimumProtocolVersion: TLSv1.2_2021
+                    SslSupportMethod: sni-only
+            Tags:
+                - Key: Domain
+                  Value: !Ref RootDomainName
+
+    CloudFrontOriginAccessIdentity:
+        Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+        Properties:
+            CloudFrontOriginAccessIdentityConfig:
+                Comment: !Sub 'CloudFront OAI for www.${RootDomainName}'
+
+
+    # The record sets map your domain name to Amazon S3 endpoints.
+    Route53RecordSetGroup:
+        Type: AWS::Route53::RecordSetGroup
+        Properties:
+            # keep the . suffix
+            HostedZoneName: !Sub '${RootDomainName}.'
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html#cfn-route53-aliastarget-hostedzoneid
+            HostedZoneName: !Sub 
+                - ${Domain}.
+                - Domain: !Ref RootDomainName
+            Comment: Zone apex alias.
+            RecordSets:
+                - Name: !Ref RootDomainName
+                  Type: A
+                  AliasTarget:
+                      DNSName: !GetAtt CloudFrontDistribution.DomainName
+                      EvaluateTargetHealth: false
+                      HostedZoneId: Z2FDTNDATAQYW2 # leave hardcoded, don't confuse w/ !Ref HostedZoneId
+                - Name: !Sub 'www.${RootDomainName}'
+                  Type: A
+                  AliasTarget:
+                      DNSName: !GetAtt CloudFrontDistribution.DomainName
+                      EvaluateTargetHealth: false
+                      HostedZoneId: Z2FDTNDATAQYW2 # leave hardcoded, don't confuse w/ !Ref HostedZoneId
+
+ CloudFrontFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      AutoPublish: true
+      Name: add-index_html
+      FunctionCode: !Sub |
+        function handler(event) {
+            var request = event.request;
+            var uri = request.uri;
+
+            // Check whether the URI is missing a file name.
+            if (uri.endsWith('/')) {
+                request.uri += 'index.html';
+            }
+            // Check whether the URI is missing a file extension.
+            else if (!uri.includes('.')) {
+                request.uri += '/index.html';
+            }
+
+            return request;
+        }
+      FunctionConfig:
+        Comment: Add index.html to request URLs that do not include a file name
+        Runtime: cloudfront-js-1.0
+
+
+Outputs:
+    CloudFrontDistribution:
+        Description: CloudFront distribution
+        Value: !Ref CloudFrontDistribution
+    CertificateArn:
+        Description: Issued certificate
+        Value: !Ref CertificateManagerCertificate  
+    RootDomainBucket:
+        Description: Website bucket
+        Value: !Ref RootBucket
+    RootDomainBucketArn:
+        Description: Website bucket locator
+        Value: !GetAtt RootBucket.Arn
+    S3BucketBucketLogs:
+        Description: Logging bucket
+        Value: !Ref LoggingBucket
+    S3BucketBucketLogsArn:
+        Description: Logging bucket
+        Value: !GetAtt LoggingBucket.Arn


### PR DESCRIPTION
This commit sets up the hidivelab.org website which is sourced from an S3 bucket and served via a CloudFront distribution.  The static-site.yaml is a Cloudformation template for deploying the AWS resources. It provisions two S3 buckets for hosting the content and logs, respectively. A certificate is created to support https. The CloudFront distribution includes a function association to add index.html to request URLs that do not contain a file name. This does not include redirection of the existing gehlenborglab.org site to hidivelab.org.

Updates GitHub actions to deploy to S3 bucket in hdv_lab account.