### PR TITLE
Add global h1 to publications and change preprints back to h2

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -4,10 +4,12 @@ title: Publications
 permalink: /publications/
 ---
 
+<h1>Publications</h1>
+
 <table class="publications">
 
 <tr><td colspan="2">
-  <h1>Preprints</h1>
+  <h2>Preprints</h2>
 </td></tr>
 
 {% for publication in site.publications %}


### PR DESCRIPTION
Currently, 'preprints' is an h1 element, and all the other years are h2 elements. The 'preprints' and '2024', '2023', etc., should be the same level. 