### PR TITLE
Fix YAML format

### DIFF
--- a/cloudformation/static-site.yaml
+++ b/cloudformation/static-site.yaml
@@ -207,10 +207,10 @@ Resources:
                       EvaluateTargetHealth: false
                       HostedZoneId: Z2FDTNDATAQYW2 # leave hardcoded, don't confuse w/ !Ref HostedZoneId
 
- # This function replicates the Amazon S3 behavior that directs any request that lacks a filename to index.html,
- # regardless of whether it's for the root of a website or a subfolder.
- # https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
- CloudFrontFunction:
+# This function replicates the Amazon S3 behavior that directs any request that lacks a filename to index.html,
+# regardless of whether it's for the root of a website or a subfolder.
+# https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
+CloudFrontFunction:
     Type: AWS::CloudFront::Function
     Properties:
       AutoPublish: true

--- a/cloudformation/static-site.yaml
+++ b/cloudformation/static-site.yaml
@@ -207,33 +207,33 @@ Resources:
                       EvaluateTargetHealth: false
                       HostedZoneId: Z2FDTNDATAQYW2 # leave hardcoded, don't confuse w/ !Ref HostedZoneId
 
-# This function replicates the Amazon S3 behavior that directs any request that lacks a filename to index.html,
-# regardless of whether it's for the root of a website or a subfolder.
-# https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
-CloudFrontFunction:
-    Type: AWS::CloudFront::Function
-    Properties:
-      AutoPublish: true
-      Name: add-index_html
-      FunctionCode: !Sub |
-        function handler(event) {
-            var request = event.request;
-            var uri = request.uri;
+    # This function replicates the Amazon S3 behavior that directs any request that lacks a filename to index.html,
+    # regardless of whether it's for the root of a website or a subfolder.
+    # https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
+    CloudFrontFunction:
+        Type: AWS::CloudFront::Function
+        Properties:
+            AutoPublish: true
+            Name: add-index_html
+            FunctionCode: !Sub |
+                function handler(event) {
+                    var request = event.request;
+                    var uri = request.uri;
 
-            // Check whether the URI is missing a file name.
-            if (uri.endsWith('/')) {
-                request.uri += 'index.html';
-            }
-            // Check whether the URI is missing a file extension.
-            else if (!uri.includes('.')) {
-                request.uri += '/index.html';
-            }
+                    // Check whether the URI is missing a file name.
+                    if (uri.endsWith('/')) {
+                        request.uri += 'index.html';
+                    }
+                    // Check whether the URI is missing a file extension.
+                    else if (!uri.includes('.')) {
+                        request.uri += '/index.html';
+                    }
 
-            return request;
-        }
-      FunctionConfig:
-        Comment: Add index.html to request URLs that do not include a file name
-        Runtime: cloudfront-js-1.0
+                    return request;
+                }
+            FunctionConfig:
+                Comment: Add index.html to request URLs that do not include a file name
+                Runtime: cloudfront-js-1.0
 
 
 Outputs:


### PR DESCRIPTION
When I tried to run the `static-site.yaml`, I got the following error. 

> An error occurred (ValidationError) when calling the CreateStack operation: Template format error: YAML not well-formed. (line 213, column 2)

```
_# This function replicates the Amazon S3 behavior that directs any request that lacks a filename to index.html,
_# regardless of whether it's for the root of a website or a subfolder.
_# https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
_CloudFrontFunction: ← Line 213, one space for indentation seems to be the issue
```