### PR TITLE
fix: Use correct preprint link for CEV

### DIFF
--- a/_publications/manz-cev-2024.md
+++ b/_publications/manz-cev-2024.md
@@ -10,7 +10,7 @@ type: preprint
 publisher: "https://doi.org/10.31219/osf.io/puxnf"
 cite:
   authors: "Trevor Manz, Fritz Lekschas, Evan Greene, Greg Finak, Nils Gehlenborg"
-  published: "Accepted at IEEE VIS 2021 and IEEE Transactions on Visualization and Computer Graphics."
+  published: "*OSF Preprints* doi: 10.31219/osf.io/puxnf"
 ---
 Projecting high-dimensional vectors into two dimensions for visualization,
 known as embedding visualization, facilitates perceptual reasoning and

--- a/_publications/manz-cev-2024.md
+++ b/_publications/manz-cev-2024.md
@@ -6,11 +6,11 @@ members:
   - fritz-lekschas
   - nils-gehlenborg
 year: 2024
-type: preprint
+type: article
 publisher: "https://doi.org/10.31219/osf.io/puxnf"
 cite:
   authors: "Trevor Manz, Fritz Lekschas, Evan Greene, Greg Finak, Nils Gehlenborg"
-  published: "*OSF Preprints* doi: 10.31219/osf.io/puxnf"
+  published: "Accepted at IEEE VIS 2024 and IEEE Transactions on Visualization and Computer Graphics"
 ---
 Projecting high-dimensional vectors into two dimensions for visualization,
 known as embedding visualization, facilitates perceptual reasoning and


### PR DESCRIPTION
Copied the `published` from another entry and forgot to update. Thanks @EricMoerthVis 