### PR TITLE
Add paper-bot: prefix to automated PRs

### DIFF
--- a/.github/workflows/update-paper.yml
+++ b/.github/workflows/update-paper.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: Update paper
-          title: "${{ github.event.issue.title }}"
+          commit-message: "paper-bot: Update ${ steps.extract-zotero-id.outputs.zotero-id }"
+          title: "paper-bot: Update ${ steps.extract-zotero-id.outputs.zotero-id }"
           branch: "update-paper-${{ steps.extract-zotero-id.outputs.zotero-id }}"
           body-path: /tmp/pr-body.md
           labels: paper-bot


### PR DESCRIPTION
Adds a consistent prefix to paper-bot PRs. PRs from this automation will now be titled: "paper-bot: Update \<zotero-id\>"
