### PR TITLE
Escape title in publication image alt text

### DIFF
--- a/_includes/publication-row.html
+++ b/_includes/publication-row.html
@@ -1,7 +1,7 @@
 <tr>
 <td>
 {% if publication.image %}
-<a class="display-lg-only" href="{{publication.url}}"><img alt='Publication page for "{{ publication.title }}"' class="thumb" src="/assets/img/publications/thumbnail/{{ publication.image }}"></a>
+<a class="display-lg-only" href="{{publication.url}}"><img alt='Publication page for "{{ publication.title | escape }}"' class="thumb" src="/assets/img/publications/thumbnail/{{ publication.image }}"></a>
 {% endif %}
 </td>
 <td>


### PR DESCRIPTION
The alt text in the publications row template isn't appropriately escaped, so
it's breaking the generated HTML and there is a bad layout shift/bug on the
site. This PR fixes that by escaping the alt text in the publications row
template.

Example:

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/e5c01a7c-64f5-4a3f-89a7-c27519719180">

The `'` in "Don't" breaks the quoting and the image tag.
