### PR TITLE
Remove a description about `<TODO>`

### DIFF
--- a/scripts/update-hidive-paper.ts
+++ b/scripts/update-hidive-paper.ts
@@ -291,7 +291,7 @@ This is an automated PR adding a new publication to the website.
 
 > ${contents.frontmatter.cite.authors}. "${contents.frontmatter.title}", ${contents.frontmatter.cite.published} (${contents.frontmatter.year})
 
-Please review the changes and address the remaining \`<TODO>\`s in the file.
+Please review the changes.
 
 You can use the [GitHub CLI](https://cli.github.com/) to pull down this branch and make changes:
 


### PR DESCRIPTION
Sorry if I am missing something. It looks like we are not showing the `<TODO>` list anymore, but I see a related description in the PR created automatically.