### PR TITLE
Allow specifying slug for papers for more/memorable readable URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: Slug
       description: >-
-        An identifier for the publication. This is used in the URL for the publication page
+        An identifier for the paper/project. This is used in the URL for the publication page
         (e.g., `https://hidivelab.org/publications/<YYYY>-<last>-**<slug>**`).
         If left blank, the Zotero ID will be used.
       placeholder: "e.g., my-project, awesome-tool"

--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -26,9 +26,9 @@ body:
     attributes:
       label: Slug
       description: >-
-        An identifier for the paper/project. This is used in the URL for the publication page
-        (e.g., `https://hidivelab.org/publications/<YYYY>-<last>-**<slug>**`).
-        If left blank, the Zotero ID will be used.
+        An identifier for the paper/project. This is used in the URL for the publication page (e.g., `https://hidivelab.org/publications/<YYYY>-<last>-**<slug>**`).
+
+        Use lowercase letters and hyphens only. If left blank, the Zotero ID will be used.
       placeholder: "e.g., my-project, awesome-tool"
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -22,6 +22,16 @@ body:
       required: true
 
   - type: input
+    id: slug
+    attributes:
+      label: Slug
+      description: >-
+        An identifier for the publication. This is used in the URL for the publication page
+        (e.g., `https://hidivelab.org/publications/<YYYY>-<last>-**<slug>**`).
+        If left blank, the Zotero ID will be used.
+      placeholder: "e.g., my-project, awesome-tool"
+
+  - type: input
     id: preprint
     attributes:
       label: Preprint


### PR DESCRIPTION
The auto generated name for publications took the form: `<year>-<author-last>-<zotero-key>.md`

This PR adds a form entry for "slug", or an optional field for the user to specify a replacement for the `<zotero-key>` in the identifier above.

This can make the papers easier to find and URL easier to remember on the website.
