### PR TITLE
Switch to Google Fonts for Inter font

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -12,7 +12,7 @@
 // value from Bourbon.
 
 // @import url('https://fonts.googleapis.com/css?family=Merriweather:400,400i,700,700i|Source+Sans+Pro:400,400i,700,700i');
-@import url('https://rsms.me/inter/inter.css');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Noto+Sans+Mono:wght@100..900&display=swap');
 html { font-family: 'Inter', sans-serif; }
 @supports (font-variation-settings: normal) {
   html { font-family: 'Inter var', sans-serif; }


### PR DESCRIPTION
This PR switches from using rsms's CDN for Inter font to Google Fonts.

I've had a consistent issue with Inter loading from rms's CDN without cache (requests just hangs), leading to long page loading spinner and unstyled content.

Now that inter is on Google Fonts, I think we should switch to using it there since it is much more reliable CDN and faster.

Example of unstyled content:

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d48fde02-46fe-45b2-89b6-ede9ffcfe622">

