### PR TITLE
WCAG level A: container elements such as UL must not be empty

### DIFF
--- a/_includes/publication-row.html
+++ b/_includes/publication-row.html
@@ -10,16 +10,26 @@
   {% capture citation %}{{ publication.cite.authors }}. "[{{ publication.title }}]({{ publication.url }})", {{ publication.cite.published }} ({{ publication.year }}).{{ doi }}{% endcapture %}
   <p style="text-wrap: balance">{{ citation | markdownify }}</p>
 
-  <ul class="icon-list">
-    {% for award in publication.awards %}
-    <li>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="icon">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" />
-      </svg>
-      <b>{{ award }}</b>
-    </li>
-    {% endfor %}
-  </ul>
+  {% assign has_awards = false %}
+  {% for award in publication.awards %}
+    {% assign has_awards = true %}
+    {% break %}
+  {% endfor %}
+  {% if has_awards %}
+    {% comment %}
+      WCAG level A: container elements such as UL must not be empty
+    {% endcomment %}
+    <ul class="icon-list">
+      {% for award in publication.awards %}
+      <li>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="icon">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" />
+        </svg>
+        <b>{{ award }}</b>
+      </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 
   </td>
 </tr>


### PR DESCRIPTION
Update the `ul.icon-list` in the `_includes/publication-row.html` file to remediate a `Container element is empty` WCAG Level A issue (125 occurrences)

## More info (from [SiteImprove](https://help.siteimprove.com/support/solutions/articles/80001051793-accessibility-rule-container-element-is-empty-explained)):

> A container element for an unordered list,` <ul>`, should not exist without the list items, `<li>`. 
>
> ## Who is impacted by this barrier?
> 
> When elements are correctly grouped, blind or low-vision screen reader users are able to easier understand the contexts and structures that are present on the website. If the content is not properly structured, navigating the website can be very confusing. For instance, if you encounter a list on the website, you would expect it to have list items. Otherwise, you might wonder if some information is hidden or missing.