### PR TITLE
fix: Replace old BLV slug with new

### DIFF
--- a/_teams/accessibility/index.md
+++ b/_teams/accessibility/index.md
@@ -24,7 +24,7 @@ publications:
   - smits-2024-altgosling-osf  
   - lyi-2024-F8FYKQP6
   - weru-2024-accessibility-keyboard
-  - smits-2024-S4RH9GKM
+  - smits-2024-P3XRGF6H
 
 collaborators:
   - alexander-lex

--- a/_teams/accessibility/mental-models-blv.md
+++ b/_teams/accessibility/mental-models-blv.md
@@ -10,7 +10,7 @@ image_alt: Two-by-two grid with sketches (top row) and schematics (bottom row). 
 
 
 publications:
-  - smits-2024-S4RH9GKM
+  - smits-2024-P3XRGF6H
 
 ---
 


### PR DESCRIPTION
Site will be broken until this is approved.

The changes introduced in #549 break the site because the old slug used
for the preprint is no longer available. This PR updates the slug for
the corresponding pages.
