### PR TITLE
Export lab members to `members.csv`

### DIFF
--- a/_members/chris-briggs.md
+++ b/_members/chris-briggs.md
@@ -13,7 +13,7 @@ services:
   #twitter: 
   linked-in: https://www.linkedin.com/in/chrisbriggslinkedinprofile/
   
-start: Dec 2019
+start: December 2019
 end: January 2022
 ---
 Chris Briggs received her PhD in cell & molecular biology from Boston University.

--- a/_members/cynthia-rosas.md
+++ b/_members/cynthia-rosas.md
@@ -1,15 +1,16 @@
 ---
 title: Cynthia Rosas
+name_degree: Cynthia Rosas
 
 photo: placeholder.png # this file is relative to `assets/img/members/`
 
 job_title: DBMI Summer Institute Intern
-role: alumni 
+role: alumni
 
 services:
   github: https://github.com/cjrosa23
   linked-in: https://www.linkedin.com/in/cynthia-rosas-a15519214/
-  
+
 start: June 2021
 end: August 2021
 ---

--- a/_members/emily-hang.md
+++ b/_members/emily-hang.md
@@ -7,6 +7,6 @@ job_title: Graduate Student
 role: student
 services: []
 start: October 2024
-end: ''
+end:
 ---
 Rotation student in biomedical informatics.

--- a/_members/evan-biederstedt.md
+++ b/_members/evan-biederstedt.md
@@ -12,8 +12,7 @@ services:
   home: https://celltype.info/
   github: https://github.com/evanbiederstedt
 
-  
-start: 
+start: April 2022
 end:
 ---
 Evan is a computational biologist with a background both in cancer genomics and in single-cell genomics with the [Peter Kharchenko Lab](https://github.com/kharchenkolab/). He is now spearheading the development of the Cell Annotation Platform (CAP), infrastructure designed to improve our ability to interpret cellular state by facilitating the accumulation, sharing and analysis of relevant metadata and molecular signatures. He is also part of the [Alexandra-Chloé Villani Lab](https://villani.mgh.harvard.edu/) at Massachusetts General Hospital and the Broad Institute.

--- a/_members/furui-cheng.md
+++ b/_members/furui-cheng.md
@@ -11,7 +11,7 @@ role: alumni
 services:
   github: https://github.com/ChengFR
 
-start: Feb 2022
+start: February 2022
 end: May 2022
 ---
 [Furui Cheng](https://www.furuicheng.tech/) is a CS PhD student at the Hong Kong University of Science and Technology, advised by Prof. Huamin Qu. 

--- a/assets/members.csv
+++ b/assets/members.csv
@@ -1,0 +1,90 @@
+name,title,role,start,end
+John Conroy,Software Developer,staff,2020-04,
+Etowah Adams,Software Developer,staff,2023-03,
+Chuck McCallum,Senior Software Developer,alumni,2016-09,2022-10
+Matthew Roy,Administrative and Research Assistant,alumni,2015-11,2017-09
+Undina Gisladottir,Research Associate,alumni,2018-06,2019-07
+First Last,Visiting Scholar,student,2020-05,
+Cynthia Rosas,DBMI Summer Institute Intern,alumni,2021-06,2021-08
+Astrid van den Brandt,Visiting Graduate Student in Computer Science,student,2023-08,
+Thomas Smits,Associate in Biomedical Informatics,staff,2022-02,
+Sydney Meyer,HuBMAP Intern,alumni,2023-06,2023-08
+Lina Chi,Visiting Scholar in Biomedical Informatics,alumni,2018-06,2018-08
+Sehi L'Yi,Research Fellow in Biomedical Informatics,postdoc,2020-02,
+Devin Lange,Research Fellow in Biomedical Informatics,postdoc,2024-08,
+Trevor Manz,Research Fellow in Biomedical Informatics,postdoc,2018-06,
+Morgan Turner,R&D Manager and Visualization Scientist,staff,2022-12,
+Peter Kerpedjiev,Research Fellow in Biomedical Informatics,alumni,2016-04,2018-11
+Roselkis Morla Adames,HuBMAP Intern,alumni,2021-06,2021-08
+Mark Keller,Graduate Student in Bioinformatics,student,2019-06,
+Nikhil Kumar,BD2K Summer Institute Intern,alumni,2016-06,2016-08
+Evan Biederstedt,Computational Biologist,staff,2022-04,
+Margaret Vella,Project Manager,alumni,2018-11,2022-07
+Thomas Varley,DBMI Summer Institute Intern,alumni,2020-06,2020-08
+Huyen N. Nguyen,Research Fellow in Biomedical Informatics,postdoc,2023-09,
+Xinyi Liu,Postgraduate Research Intern,alumni,2023-06,2023-08
+Angela Chen,DBMI Summer Institute Intern,alumni,2018-06,2018-08
+Megan Paul,BD2K Summer Institute Intern,alumni,2016-06,2016-08
+Mary Futey,Data Curator,staff,2021-11,
+Danielle Nguyen,Co-op Student,alumni,2018-01,2018-10
+Anton Xue,High School Intern,alumni,2014-06,2015-06
+Jacob Luber,Graduate Student in Biomedical Informatics,alumni,2016-09,2016-12
+Yan Ma,Project Coordinator,staff,2024-06,
+Drashko Nakikj,Research Fellow in Biomedical Informatics,alumni,2019-04,2022-02
+Thomas Chan,DBMI Summer Institute Intern,alumni,2019-06,2019-08
+Siyoung Kim,SIBMI / DBMI Summer Institute Intern,alumni,2024-06,2024-08
+Lindsey Fernandez,BD2K Summer Institute Intern,alumni,2015-06,2015-08
+Samson Mataraso,BD2K Summer Institute Intern,alumni,2017-06,2017-08
+Jake Conway,Graduate Student in Biomedical Informatics,alumni,2015-06,2017-03
+Man Qing Liang,Research Fellow in Biomedical Informatics,alumni,2022-09,2023-03
+Erica Stutz,DBMI Summer Institute Intern,alumni,2022-06,2022-08
+Zahra Shakeri,Research Fellow in Biomedical Informatics,alumni,2021-07,2022-07
+Sabrina Nusrat,Research Fellow in Biomedical Informatics,alumni,2018-01,2019-10
+Samson Toor,Senior UI/UX Designer,alumni,2023-10,2024-06
+Katrina Liu,Graduate Student in Biomedical Informatics,alumni,2022-09,2023-05
+Furui Cheng,Visiting Graduate Student,alumni,2022-02,2022-05
+Qianwen Wang,Research Fellow in Biomedical Informatics,alumni,2020-05,2023-08
+Kevin Yoo,Software Developer,alumni,2023-05,2023-08
+Stefan Luger,External Master's Student,alumni,2014-09,2015-12
+Theresa Anisja Harbig,Research Associate,alumni,2018-01,2019-09
+Austen Money,Software Developer,staff,2024-07,
+Zoey Ho,Graduate Student in Biomedical Informatics,alumni,2019-01,2020-05
+Jennifer Chen,DBMI Summer Institute Intern,alumni,2024-06,2024-08
+Sofia Rojas,Research Assistant,student,2023-10,
+Jeremy Liu,i2b2 Summer Institute Intern,alumni,2014-06,2014-08
+Jennifer K Marx,Software Engineer,alumni,2015-05,2020-03
+Mimi Alkattan,Associate and Project Coordinator,alumni,2023-06,2023-12
+Matthew Scott Tan,Undergraduate Student in Mathematics and Statistics,alumni,2023-09,2023-12
+Alaleh Azhir,BD2K Summer Institute Intern,alumni,2016-06,2016-08
+Lisa Choy,Principal Software Developer,staff,2023-03,
+Justine Shih,DBMI Summer Institute Intern,alumni,2019-06,2019-08
+Tessa Han,Graduate Student in Biomedical Informatics,alumni,2021-02,2021-06
+Carolina Nobre,Visiting Graduate Student in Computer Science,alumni,2017-05,2017-08
+Eric Moerth,Research Fellow in Biomedical Informatics,postdoc,2023-04,
+Fritz Lekschas,Graduate Student in Computer Science,alumni,2015-04,2021-05
+Emily Hang,Graduate Student,student,2024-10,
+Mohamed Yousry ElSadec,DBMI Summer Institute Intern,alumni,2023-06,2023-12
+Julian Zulueta,DBMI Summer Institute Intern,alumni,2022-06,2022-08
+Claudia Meyer,DBMI Summer Institute Intern,alumni,2019-06,2019-08
+Tram Nguyen,HuBMAP Intern,alumni,2022-06,2022-08
+Liam Wang,DBMI Summer Institute Intern,alumni,2023-06,2023-08
+Nikolay Akhmetov,Software Developer,staff,2020-09,
+Nichole Parker,Administrative and Research Assistant,administration,2017-09,
+Vimig Socrates,BD2K Summer Institute Intern,alumni,2017-06,2017-08
+Tiffany Liaw,UI/UX Developer,staff,2020-04,
+PJ Van Camp,Curriculum Fellow in Biomedical Informatics,postdoc,2022-07,
+Aditeya Pandey,Visiting Graduate Student in Computer Science,alumni,2020-05,2022-10
+Aarti Darji,HuBMAP Summer Intern,student,2024-06,
+Nils Gehlenborg,Associate Professor of Biomedical Informatics,pi,2015-04,
+Karan Luthria,Visiting Undergraduate Student,alumni,2020-06,2020-08
+Andrew Mar,Research Assistant,student,2024-03,
+David Kouřil,Research Fellow in Biomedical Informatics,postdoc,2023-07,
+Chris Briggs,Senior Data Curator,alumni,2019-12,2022-01
+Pinar Ozden Eser,Associated Scientist,postdoc,2021-05,
+Scott Ouellette,Software Developer,alumni,2015-07,2019-02
+Tabassum Kakar,Software Developer,staff,2024-07,
+Ilan Gold,Software Developer,alumni,2019-08,2024-04
+Lawrence Weru,Associate in Biomedical Informatics,staff,2023-10,
+Eva Christine Schitter,Visiting Graduate Student in Biomedical Informatics,alumni,2017-03,2017-07
+Max Wolf,Curriculum Fellow in Biomedical Informatics,alumni,2019-09,2022-08
+

--- a/scripts/create-hidive-member.ts
+++ b/scripts/create-hidive-member.ts
@@ -87,7 +87,7 @@ function toMarkdown({ biography, ...m }: Member): string {
     role: m.role,
     services: m.social_media?.map((x) => `${x.title}: ${x.url}`) ?? [],
     start: m.start_date,
-    end: "",
+    end: null,
   };
   let fm = yaml.stringify(frontmatter, { lineWidth: 120 });
   let body = biography.trim();


### PR DESCRIPTION
Adds script `./scripts/export-lab-members.ts` which:

1.) Parses and validates member metadata from `_members`
2.) Prints the data serialized to `.csv` format to stdout

I have checked in the output of the file into `assets/member.csv`

```sh
deno run -A scripts/export-lab-members.ts > assets/members.csv
```

Members with invalid metadata will be printed nicely to the console to help with resolving these data quality issues.