### PR TITLE
Re-export members to include George

### DIFF
--- a/assets/members.csv
+++ b/assets/members.csv
@@ -5,7 +5,6 @@ George Bandek,Lab Coordinator,administration,2024-12,
 Chuck McCallum,Senior Software Developer,alumni,2016-09,2022-10
 Matthew Roy,Administrative and Research Assistant,alumni,2015-11,2017-09
 Undina Gisladottir,Research Associate,alumni,2018-06,2019-07
-First Last,Visiting Scholar,student,2020-05,
 Cynthia Rosas,DBMI Summer Institute Intern,alumni,2021-06,2021-08
 Astrid van den Brandt,Visiting Graduate Student in Computer Science,student,2023-08,
 Thomas Smits,Associate in Biomedical Informatics,staff,2022-02,

--- a/assets/members.csv
+++ b/assets/members.csv
@@ -1,6 +1,7 @@
 name,title,role,start,end
 John Conroy,Software Developer,staff,2020-04,
 Etowah Adams,Software Developer,staff,2023-03,
+George Bandek,Lab Coordinator,administration,2024-12,
 Chuck McCallum,Senior Software Developer,alumni,2016-09,2022-10
 Matthew Roy,Administrative and Research Assistant,alumni,2015-11,2017-09
 Undina Gisladottir,Research Associate,alumni,2018-06,2019-07
@@ -87,4 +88,3 @@ Ilan Gold,Software Developer,alumni,2019-08,2024-04
 Lawrence Weru,Associate in Biomedical Informatics,staff,2023-10,
 Eva Christine Schitter,Visiting Graduate Student in Biomedical Informatics,alumni,2017-03,2017-07
 Max Wolf,Curriculum Fellow in Biomedical Informatics,alumni,2019-09,2022-08
-

--- a/scripts/export-lab-members.ts
+++ b/scripts/export-lab-members.ts
@@ -1,9 +1,11 @@
 /**
- * @module A script to export HIDIVE lab members (from '../_members/') to a CSV.
+ * @module Export HIDIVE lab members (from '../_members/') to a CSV ('../assets/members.csv').
+ *
+ * @see {@link LabMemberSchema} below for output schema.
  *
  * @example
  * ```sh
- * deno run -A export-lab-members.ts > ../assets/members.csv
+ * deno run -A export-lab-members.ts
  * ```
  */
 import * as csv from "jsr:@std/csv@1.0.4";
@@ -82,5 +84,9 @@ if (import.meta.main) {
 		}
 		members.push(result.data);
 	}
-	console.log(csv.stringify(members, { columns: Object.keys(members[0]) }));
+
+	await Deno.writeTextFile(
+		new URL("../assets/members.csv", import.meta.url),
+		csv.stringify(members, { columns: Object.keys(members[0]) }),
+	);
 }

--- a/scripts/export-lab-members.ts
+++ b/scripts/export-lab-members.ts
@@ -56,7 +56,7 @@ if (import.meta.main) {
 	let membersDir = new URL("../_members/", import.meta.url);
 	let members: Array<LabMember> = [];
 	for await (const entry of Deno.readDir(membersDir)) {
-		if (entry.isDirectory) {
+		if (entry.isDirectory || entry.name == "template.md") {
 			continue;
 		}
 		let contents = await Deno.readTextFile(


### PR DESCRIPTION
Also updates script to write the `assets/members.csv` directly (instead of a requiring pipe) and ignores template.
