### PR TITLE
add optional date to news issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/news.yml
+++ b/.github/ISSUE_TEMPLATE/news.yml
@@ -19,6 +19,13 @@ body:
       required: true
 
   - type: input
+    id: date
+    attributes:
+      label: Date
+      description: "The date of the announcement (YYYY-MM-DD). If left blank, today's date will be used."
+      placeholder: "e.g., 2025-02-28"
+
+  - type: input
     id: title
     attributes:
       label: Title

--- a/scripts/create-hidive-news.ts
+++ b/scripts/create-hidive-news.ts
@@ -43,6 +43,11 @@ let issueTemplateSchema = z.object({
     .optional()
     .transform((x) => x?.trim())
     .transform((x) => x === "" ? undefined : x),
+  date: z.string()
+    .nullable()
+    .optional()
+    .transform((x) => x?.trim())
+    .transform((x) => x === "" ? new Date().toISOString().split("T")[0] : x),
   lab_members: z.string()
     .nullable()
     .optional()
@@ -72,8 +77,7 @@ function toMarkdown({ announcement, ...frontmatter }: News): string {
   return `---\n${fm}---\n${body}${body.endsWith("\n") ? "" : "\n"}`;
 }
 
-function getFilename({ title, slug }: News): string {
-  let date = new Date().toISOString().split("T")[0];
+function getFilename({ title, slug, date }: News): string {
   let base = slug ?? title.toLowerCase().replace(/[^\w]+/g, "-");
   // ensure ends with .md
   if (!base.endsWith(".md")) {

--- a/scripts/create-hidive-news.ts
+++ b/scripts/create-hidive-news.ts
@@ -47,7 +47,9 @@ let issueTemplateSchema = z.object({
     .nullable()
     .optional()
     .transform((x) => x?.trim())
-    .transform((x) => x === "" ? new Date().toISOString().split("T")[0] : x),
+    .transform((x) =>
+      (x === undefined || x === "") ? new Date().toISOString().split("T")[0] : x
+    ),
   lab_members: z.string()
     .nullable()
     .optional()


### PR DESCRIPTION
> Maybe the template can be revised to allow setting a date
> We often don’t get to making the announcement when it happens
\- Nils

(and also easier for a backfill)