### PR TITLE
Add explicit input for alt text in paper form

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-member.yml
+++ b/.github/ISSUE_TEMPLATE/new-member.yml
@@ -43,6 +43,13 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: image_alt
+    attributes:
+      label: Image Alt Text
+      description: "Provide alternative text summarizing image for accessibility. See [other members](https://github.com/hms-dbmi/gehlenborglab-website/tree/main/_members) for examples. If you have uploaded an image above, **alt text is required.**"
+      placeholder: "E.g., Headshot of a smiling middle-aged white man with a shaved head and round glasses with brown frames. He is wearing a black button down shirt in front of a solid light-colored background."
+
   - type: input
     id: job_title
     attributes:

--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -66,7 +66,7 @@ body:
     id: image_alt
     attributes:
       label: Image Alt Text
-      description: "Provide alternative text summarizing high-level concepts from the image for accessibility. See [other publications https://github.com/hms-dbmi/gehlenborglab-website/tree/main/_publications) for examples."
+      description: "Provide alternative text summarizing image for accessibility. See [other publications](https://github.com/hms-dbmi/gehlenborglab-website/tree/main/_publications) for examples. If you have uploaded an image above, **alt text is required.**"
       placeholder: "E.g., Overview of eye-tracking methods and visual problem-solving strategies (self-correction, cognitive slips, uncertain reasoning)."
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -62,6 +62,13 @@ body:
       description: "Add an image related to the publication"
       placeholder: "Drag and drop or paste an image... (ensure it uploads)"
 
+  - type: textarea
+    id: image_alt
+    attributes:
+      label: Image Alt Text
+      description: "Provide alternative text summarizing high-level concepts from the image for accessibility. See [other publications https://github.com/hms-dbmi/gehlenborglab-website/tree/main/_publications) for examples."
+      placeholder: "E.g., Overview of eye-tracking methods and visual problem-solving strategies (self-correction, cognitive slips, uncertain reasoning)."
+
   - type: input
     id: website
     attributes:

--- a/.github/ISSUE_TEMPLATE/paper.yml
+++ b/.github/ISSUE_TEMPLATE/paper.yml
@@ -67,7 +67,7 @@ body:
     attributes:
       label: Image Alt Text
       description: "Provide alternative text summarizing image for accessibility. See [other publications](https://github.com/hms-dbmi/gehlenborglab-website/tree/main/_publications) for examples. If you have uploaded an image above, **alt text is required.**"
-      placeholder: "E.g., Overview of eye-tracking methods and visual problem-solving strategies (self-correction, cognitive slips, uncertain reasoning)."
+      placeholder: "e.g., Overview of eye-tracking methods and visual problem-solving strategies (self-correction, cognitive slips, uncertain reasoning)."
 
   - type: input
     id: website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
         working-directory: scripts
 
       - name: Typecheck (scripts)
-        run: deno check *.ts
+        run: deno check .
         working-directory: scripts
 

--- a/scripts/create-hidive-member.ts
+++ b/scripts/create-hidive-member.ts
@@ -10,7 +10,8 @@
  *   "slug": "jane-doe",
  *   "name": "Jane Doe",
  *   "degree": "PhD",
- *   "image": "<img alt=\"image\" src=\"https://github.com/user-attachments/assets/32f4b95c-7d2f-452e-85f5-c0351328023d\">",
+ *   "image": "<img src=\"https://github.com/user-attachments/assets/32f4b95c-7d2f-452e-85f5-c0351328023d\">",
+ *   "image_alt": "alt text for the image..",
  *   "job_title": "Postdoctoral Researcher",
  *   "role": "postdoc",
  *   "social_media": "linked-in | https://www.linkedin.com/in/jane-doe\ngithub | https://github.com/foo",
@@ -39,6 +40,10 @@ let issueTemplateSchema = z.object({
   image: z.string()
     .nullable()
     .transform(util.parseImageMarkdown),
+  image_alt: z.string()
+    .nullable()
+    .transform((x) => x?.trim())
+    .transform((x) => x === "" ? undefined : x),
   job_title: z.string().transform((x) => x.trim()),
   role: z.string().transform((x) => x.trim()),
   social_media: z
@@ -82,7 +87,7 @@ function toMarkdown({ biography, ...m }: Member): string {
     title: m.name,
     name_degree: m.degree ? `${m.name}, ${m.degree}` : m.name,
     photo: m.image.src ?? "<TODO>",
-    alt: m.image.alt ?? m.name,
+    alt: m.image_alt ?? m.name,
     job_title: m.job_title,
     role: m.role,
     services: m.social_media?.map((x) => `${x.title}: ${x.url}`) ?? [],

--- a/scripts/update-hidive-paper.ts
+++ b/scripts/update-hidive-paper.ts
@@ -57,16 +57,7 @@ let issueTemplateSchema = z.object({
     .transform((x) => x === "" ? undefined : x),
   image: z.string()
     .nullable()
-    .transform((imgTag) => {
-      imgTag = imgTag?.trim() ?? "";
-      let src = null;
-      if (imgTag.match(/<img[^>]*>/)) {
-        src = imgTag.match(/src="([^"]*)"/)?.[1] ?? null;
-      } else if (imgTag.match(/!\[[^\]]*\]\([^\)]*\)/)) {
-        src = imgTag.match(/\(([^\)]*)\)/)?.[1] ?? null;
-      }
-      return src;
-    }),
+    .transform((txt) => util.parseImageMarkdown(txt).src),
   image_alt: z.string()
     .nullable()
     .transform((x) => x?.trim())

--- a/scripts/update-hidive-paper.ts
+++ b/scripts/update-hidive-paper.ts
@@ -182,7 +182,7 @@ async function processGitHubIssue(
         title: title,
         ...(image
           ? {
-            image: image,
+            image,
             "image-alt": issue.image_alt ?? todoValue,
           }
           : {}),


### PR DESCRIPTION
Adds explicit input for image alt text to the paper issue form. I'd like to defer to @LDubya @thomcsmits @sehilyi if we can/how to include better guidelines around how to write alt text.

