### PR TITLE
typecheck/lint/format `./scripts/*.ts` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Linting (scripts)
+        run: deno lint
+        working-directory: scripts
+
+      - name: Formatting (scripts)
+        run: deno fmt --check
+        working-directory: scripts
+
+      - name: Typecheck (scripts)
+        run: deno check *.ts
+        working-directory: scripts
+

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ _site/
 .bundle/
 vendor/
 
-deno.json
 deno.lock

--- a/scripts/deno.json
+++ b/scripts/deno.json
@@ -1,0 +1,8 @@
+{
+  "lock": false,
+  "lint": {
+    "rules": {
+      "exclude": ["prefer-const"]
+    }
+  }
+}


### PR DESCRIPTION
I've been manually typechecking these scripts across various PRs
locally, but we haven't had any automated checks for them.

Now that others are contributing, this action helps maintain code
quality going forward by ensuring all `.ts` files in `scripts/` are
checked consistently.
