### PR TITLE
Change Scientific Report as `article`

### DIFF
--- a/_publications/lyi-2024-F8FYKQP6.md
+++ b/_publications/lyi-2024-F8FYKQP6.md
@@ -9,7 +9,7 @@ members:
   - sofia-rojas
   - nils-gehlenborg
 year: 2025
-type: preprint
+type: article
 publisher: 'https://doi.org/10.1038/s41598-025-08731-7'
 doi: 10.1038/s41598-025-08731-7
 cite:


### PR DESCRIPTION
I noticed that I did not update the publication `type`... This change should make our paper included under the **2025** section.