### PR TITLE
CI: move imports from deno scripts to `deno.json`

### DIFF
--- a/scripts/create-hidive-member.ts
+++ b/scripts/create-hidive-member.ts
@@ -25,8 +25,8 @@
  * deno run -A scripts/create-hidive-member.ts paper.json
  * ```
  */
-import * as yaml from "jsr:@std/yaml@1.0.5";
-import { z } from "npm:zod@3.9.8";
+import * as yaml from "@std/yaml";
+import { z } from "zod";
 import * as util from "./util.ts";
 
 type Member = z.infer<typeof issueTemplateSchema>;

--- a/scripts/create-hidive-news.ts
+++ b/scripts/create-hidive-news.ts
@@ -23,8 +23,8 @@
  * deno run -A scripts/create-hidive-news.ts paper.json
  * ```
  */
-import * as yaml from "jsr:@std/yaml@1.0.5";
-import { z } from "npm:zod@3.9.8";
+import * as yaml from "@std/yaml";
+import { z } from "zod";
 import * as util from "./util.ts";
 
 function splitLines(x: string | undefined | null): Array<string> {

--- a/scripts/deno.json
+++ b/scripts/deno.json
@@ -4,5 +4,19 @@
     "rules": {
       "exclude": ["prefer-const"]
     }
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1.0.6",
+    "@std/csv": "jsr:@std/csv@1.0.4",
+    "@std/collections": "jsr:@std/collections@^1.0.5",
+    "@std/cli": "jsr:@std/cli@1.0.6",
+    "@std/front-matter": "jsr:@std/front-matter@1.0.5",
+    "@std/fmt": "jsr:@std/fmt@1.0.2/colors",
+    "@std/fs": "jsr:@std/fs@1.0.4",
+    "@std/io": "jsr:@std/io@0.224.9",
+    "@std/path": "jsr:@std/path@1.0.6",
+    "@std/yaml": "jsr:@std/yaml@1.0.5",
+    "@clack/prompts": "npm:@clack/prompts@0.7.0",
+    "zod": "npm:zod@3.9.8",
   }
 }

--- a/scripts/export-lab-members.ts
+++ b/scripts/export-lab-members.ts
@@ -8,9 +8,9 @@
  * deno run -A export-lab-members.ts
  * ```
  */
-import * as csv from "jsr:@std/csv@1.0.4";
-import * as frontMatter from "jsr:@std/front-matter@1.0.5";
-import * as z from "npm:zod@3.23.3";
+import * as csv from "@std/csv";
+import * as frontMatter from "@std/front-matter";
+import * as z from "zod";
 
 let MONTHS = [
   "January",

--- a/scripts/fetch-hidive-zotero-items.ts
+++ b/scripts/fetch-hidive-zotero-items.ts
@@ -11,16 +11,16 @@
  * # writes assets/papers/pubs.csv, assets/papers/preprints.csv, and missing-papers.md
  * ```
  */
-import * as cli from "jsr:@std/cli@1.0.6";
-import * as colors from "jsr:@std/fmt@1.0.2/colors";
-import * as frontMatter from "jsr:@std/front-matter@1.0.5";
-import * as fs from "jsr:@std/fs@1.0.4";
-import * as p from "npm:@clack/prompts@0.7.0";
-import * as path from "jsr:@std/path@1.0.6";
-import * as yaml from "jsr:@std/yaml@1.0.5";
-import { assert } from "jsr:@std/assert@1.0.6";
-import { stringify } from "jsr:@std/csv@1.0.3";
-import { z } from "npm:zod@3.23.8";
+import * as cli from "@std/cli";
+import * as colors from "@std/fmt/colors";
+import * as frontMatter from "@std/front-matter";
+import * as fs from "@std/fs";
+import * as p from "@clack/prompts";
+import * as path from "@std/path";
+import * as yaml from "@std/yaml";
+import { assert } from "@std/assert";
+import { stringify } from "@std/csv";
+import { z } from "zod";
 
 let HIDIVE_GROUP_ID = "5145258" as const;
 let HIDIVE_PUBLICATIONS_COLLECTION_ID = "YGTEVG73" as const;

--- a/scripts/update-hidive-paper.ts
+++ b/scripts/update-hidive-paper.ts
@@ -27,9 +27,9 @@
  * deno run -A scripts/update-hidive-paper.ts paper.json
  * ```
  */
-import * as yaml from "jsr:@std/yaml@1.0.5";
-import { deepMerge } from "jsr:@std/collections@^1.0.5";
-import { z } from "npm:zod@3.9.8";
+import * as yaml from "@std/yaml";
+import { deepMerge } from "@std/collections";
+import { z } from "zod";
 import * as util from "./util.ts";
 
 import {

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,4 +1,4 @@
-import * as io from "jsr:@std/io@0.224.9";
+import * as io from "@std/io";
 
 async function readAllBytes(fname: string): Promise<Uint8Array> {
   if (fname === "-") {


### PR DESCRIPTION
Looks like deno `v2.5.0` has a new linting rule that discourages imports with the `npm:`, `jsr:`, etc. specifiers: https://deno.com/blog/v2.5#no-import-prefix-lint-rule. Because we specify the deno version in [ci.yml](https://github.com/hms-dbmi/gehlenborglab-website/blob/main/.github/workflows/ci.yml) as `deno-version: v2.x`, deno 2.5.0 was used right away today. 

This PR updates the scripts used in CI, and should resolve the Github Actions failures.